### PR TITLE
Add localization for passkey labels and actions

### DIFF
--- a/resources/lang/en/passkeys.php
+++ b/resources/lang/en/passkeys.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-// translations for MarcelWeidum/Passkeys
 return [
     //
 ];

--- a/resources/views/livewire/passkeys.blade.php
+++ b/resources/views/livewire/passkeys.blade.php
@@ -2,11 +2,10 @@
     <div>
         <form id="passkeyForm" wire:submit="validatePasskeyProperties" class="flex items-start space-x-2">
             <div class="w-full">
-                <x-filament::input.wrapper prefix="Name">
+                <x-filament::input.wrapper prefix="{{ __('passkeys::passkeys.name') }}">
                     <x-filament::input
                         type="text"
                         wire:model="name"
-                        label="Name"
                     />
                 </x-filament::input.wrapper>
 

--- a/resources/views/login.blade.php
+++ b/resources/views/login.blade.php
@@ -1,5 +1,5 @@
 <x-authenticate-passkey redirect="/admin">
     <x-filament::button icon="heroicon-o-key" color="gray" class="w-full" onclick="authenticateWithPasskey()">
-        Authenticate using Passkey
+        {{ __('passkeys::passkeys.authenticate_using_passkey') }}
     </x-filament::button>
 </x-authenticate-passkey>

--- a/src/Livewire/Passkeys.php
+++ b/src/Livewire/Passkeys.php
@@ -20,6 +20,7 @@ final class Passkeys extends PasskeysComponent implements HasActions, HasSchemas
     public function deleteAction(): Action
     {
         return Action::make('delete')
+            ->label(__('passkeys::passkeys.delete'))
             ->color('danger')
             ->requiresConfirmation()
             ->action(fn (array $arguments) => $this->deletePasskey($arguments['passkey']));


### PR DESCRIPTION
Replaced hardcoded strings in passkey-related views and actions with localization calls using the 'passkeys' language file. This improves internationalization support and prepares the UI for translation.