### PR TITLE
Add passkey creation notification and update translations

### DIFF
--- a/resources/lang/en/passkeys.php
+++ b/resources/lang/en/passkeys.php
@@ -3,5 +3,16 @@
 declare(strict_types=1);
 
 return [
-    //
+    'authenticate_using_passkey' => __('passkeys::passkeys.authenticate_using_passkey'),
+    'create' => __('passkeys::passkeys.create'),
+    'delete' => __('passkeys::passkeys.delete'),
+    'error_something_went_wrong_generating_the_passkey' => __('passkeys::passkeys.error_something_went_wrong_generating_the_passkey'),
+    'invalid' => __('passkeys::passkeys.invalid'),
+    'last_used' => __('passkeys::passkeys.last_used'),
+    'name' => __('passkeys::passkeys.name'),
+    'name_placeholder' => __('passkeys::passkeys.name_placeholder'),
+    'no_passkeys_registered' => __('passkeys::passkeys.no_passkeys_registered'),
+    'not_used_yet' => __('passkeys::passkeys.not_used_yet'),
+    'passkeys' => __('passkeys::passkeys.passkeys'),
+    'notification_success_title' => 'Your passkey has been created',
 ];

--- a/resources/views/livewire/passkeys.blade.php
+++ b/resources/views/livewire/passkeys.blade.php
@@ -2,7 +2,7 @@
     <div>
         <form id="passkeyForm" wire:submit="validatePasskeyProperties" class="flex items-start space-x-2">
             <div class="w-full">
-                <x-filament::input.wrapper prefix="{{ __('passkeys::passkeys.name') }}" :valid="! $errors->has('name')">
+                <x-filament::input.wrapper prefix="{{ __('filament-passkeys::passkeys.name') }}" :valid="! $errors->has('name')">
                     <x-filament::input
                         type="text"
                         wire:model="name"

--- a/src/Livewire/Passkeys.php
+++ b/src/Livewire/Passkeys.php
@@ -7,6 +7,7 @@ namespace MarcelWeidum\Passkeys\Livewire;
 use Filament\Actions\Action;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
+use Filament\Notifications\Notification;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
 use Illuminate\View\View;
@@ -24,6 +25,16 @@ final class Passkeys extends PasskeysComponent implements HasActions, HasSchemas
             ->color('danger')
             ->requiresConfirmation()
             ->action(fn (array $arguments) => $this->deletePasskey($arguments['passkey']));
+    }
+
+    public function storePasskey(string $passkey): void
+    {
+        parent::storePasskey($passkey);
+
+        Notification::make()
+            ->title(__('filament-passkeys::passkeys.notification_success_title'))
+            ->success()
+            ->send();
     }
 
     public function render(): View


### PR DESCRIPTION
Introduces a success notification when a passkey is created in the Passkeys Livewire component. Updates language keys in passkeys.php and corrects translation namespace usage in the Blade view.