### PR TITLE
(Possible) fix path for filament-passkeys css asset

### DIFF
--- a/src/PasskeysServiceProvider.php
+++ b/src/PasskeysServiceProvider.php
@@ -96,7 +96,7 @@ final class PasskeysServiceProvider extends PackageServiceProvider
     protected function getAssets(): array
     {
         return [
-            Css::make('filament-passkeys-styles', __DIR__.'./../resources/dist/filament-passkeys.css'),
+            Css::make('filament-passkeys-styles', __DIR__.'/../resources/dist/filament-passkeys.css'),
             Js::make('filament-passkeys-scripts', __DIR__.'/../resources/dist/filament-passkeys.js'),
         ];
     }


### PR DESCRIPTION
This pull request includes a minor (possible) fix to the asset path in the `getAssets` method on windows of the `PasskeysServiceProvider` class. The change corrects the relative path to the css file to ensure assets are loaded properly.