### PR TITLE
Update redirect URL in authenticate-passkey component

### DIFF
--- a/resources/views/login.blade.php
+++ b/resources/views/login.blade.php
@@ -1,4 +1,4 @@
-<x-authenticate-passkey redirect="/admin">
+<x-authenticate-passkey redirect="{{ filament()->getCurrentPanel()->getUrl() }}">
     <x-filament::button icon="heroicon-o-key" color="gray" class="w-full" onclick="authenticateWithPasskey()">
         {{ __('passkeys::passkeys.authenticate_using_passkey') }}
     </x-filament::button>


### PR DESCRIPTION
Fixes 404 when panel is not at `/admin` (hardcoded)