### PR TITLE
Per-panel enable/disable option for the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,22 @@ php artisan migrate
 Route::passkeys();
 ```
 
+5. Add passkeys plugin to your Filament Panel
+
+Add passkeys to a panel by adding the class to your Filament Panel's plugin() or plugins([]) method.
+
+```php
+use MarcelWeidum\Passkeys\PasskeysPlugin;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        ->plugins([
+            PasskeysPlugin::make(),
+        ])
+}
+```
+
 (Optional) If you want to customize the translations, you can publish the translations by running:
 
 ```bash

--- a/src/PasskeysPlugin.php
+++ b/src/PasskeysPlugin.php
@@ -4,8 +4,14 @@ declare(strict_types=1);
 
 namespace MarcelWeidum\Passkeys;
 
+use Filament\Auth\Pages\EditProfile;
 use Filament\Contracts\Plugin;
 use Filament\Panel;
+use Filament\Support\Facades\FilamentView;
+use Filament\View\PanelsRenderHook;
+use Illuminate\View\View;
+use Livewire\Livewire;
+use MarcelWeidum\Passkeys\Livewire\Passkeys as LivewirePasskeys;
 
 final class PasskeysPlugin implements Plugin
 {
@@ -34,6 +40,23 @@ final class PasskeysPlugin implements Plugin
 
     public function boot(Panel $panel): void
     {
-        //
+        FilamentView::registerRenderHook(
+            PanelsRenderHook::AUTH_LOGIN_FORM_AFTER,
+            fn (): View => view('filament-passkeys::login'),
+        );
+
+        FilamentView::registerRenderHook(
+            PanelsRenderHook::SIMPLE_PAGE_END,
+            fn (): View => view('filament-passkeys::profile'),
+            scopes: EditProfile::class,
+        );
+
+        FilamentView::registerRenderHook(
+            PanelsRenderHook::PAGE_END,
+            fn (): View => view('filament-passkeys::profile'),
+            scopes: EditProfile::class,
+        );
+
+        Livewire::component('filament-passkeys', LivewirePasskeys::class);
     }
 }

--- a/src/PasskeysServiceProvider.php
+++ b/src/PasskeysServiceProvider.php
@@ -4,16 +4,10 @@ declare(strict_types=1);
 
 namespace MarcelWeidum\Passkeys;
 
-use Filament\Auth\Pages\EditProfile;
 use Filament\Support\Assets\Asset;
 use Filament\Support\Assets\Css;
 use Filament\Support\Assets\Js;
 use Filament\Support\Facades\FilamentAsset;
-use Filament\Support\Facades\FilamentView;
-use Filament\View\PanelsRenderHook;
-use Illuminate\View\View;
-use Livewire\Livewire;
-use MarcelWeidum\Passkeys\Livewire\Passkeys as LivewirePasskeys;
 use Spatie\LaravelPackageTools\Commands\InstallCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -64,25 +58,6 @@ final class PasskeysServiceProvider extends PackageServiceProvider
             $this->getAssets(),
             $this->getAssetPackageName()
         );
-
-        FilamentView::registerRenderHook(
-            PanelsRenderHook::AUTH_LOGIN_FORM_AFTER,
-            fn (): View => view('filament-passkeys::login'),
-        );
-
-        FilamentView::registerRenderHook(
-            PanelsRenderHook::SIMPLE_PAGE_END,
-            fn (): View => view('filament-passkeys::profile'),
-            scopes: EditProfile::class,
-        );
-
-        FilamentView::registerRenderHook(
-            PanelsRenderHook::PAGE_END,
-            fn (): View => view('filament-passkeys::profile'),
-            scopes: EditProfile::class,
-        );
-
-        Livewire::component('filament-passkeys', LivewirePasskeys::class);
     }
 
     protected function getAssetPackageName(): string


### PR DESCRIPTION
This pull request refactors the registration of render hooks and Livewire components for the Passkeys plugin, moving this logic from the `PasskeysServiceProvider` to the `PasskeysPlugin` class. This change improves code organization by ensuring plugin-specific UI and Livewire setup are handled within the plugin itself, rather than the service provider.

**Plugin architecture improvements:**

* Moved registration of Filament render hooks (`AUTH_LOGIN_FORM_AFTER`, `SIMPLE_PAGE_END`, `PAGE_END`) and their associated views from `PasskeysServiceProvider` to the `PasskeysPlugin` class, centralizing plugin UI setup. [[1]](diffhunk://#diff-e837978b41459860c61df98d7201bc7dcb076a173e4caa4a17aa6a45d50bfce9L37-R60) [[2]](diffhunk://#diff-80b98d37658afc6a15e72d6ea59a7716de99d859faba37c1ea2ca1122acf087bL67-L85)
* Registered the Livewire component `filament-passkeys` in the `PasskeysPlugin` class instead of the service provider, improving separation of concerns. [[1]](diffhunk://#diff-e837978b41459860c61df98d7201bc7dcb076a173e4caa4a17aa6a45d50bfce9L37-R60) [[2]](diffhunk://#diff-80b98d37658afc6a15e72d6ea59a7716de99d859faba37c1ea2ca1122acf087bL67-L85)

**Code cleanup:**

* Removed unused imports from `PasskeysServiceProvider.php` that are now handled in `PasskeysPlugin.php`. [[1]](diffhunk://#diff-80b98d37658afc6a15e72d6ea59a7716de99d859faba37c1ea2ca1122acf087bL7-L16) [[2]](diffhunk://#diff-e837978b41459860c61df98d7201bc7dcb076a173e4caa4a17aa6a45d50bfce9R7-R14)