### PR TITLE
Fix livewire component registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This package is using the [passkeys package from spatie](https://spatie.be/docs/
 
 &nbsp;
 
+**Version compatibility:** `3.x` supports Filament v5. For Filament v3 and v4, use the [`2.x` branch](https://github.com/MarcelWeidum/filament-passkeys/tree/2.x).
+
 ## Installation
 
 1. Install the package via composer:

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "filament/filament": "^4.0|^5.0",
+        "filament/filament": "^5.0",
         "spatie/laravel-package-tools": "^1.15.0",
         "spatie/laravel-passkeys": "^1.5.3",
         "web-auth/webauthn-lib": "5.2.3"

--- a/src/PasskeysPlugin.php
+++ b/src/PasskeysPlugin.php
@@ -10,8 +10,6 @@ use Filament\Panel;
 use Filament\Support\Facades\FilamentView;
 use Filament\View\PanelsRenderHook;
 use Illuminate\View\View;
-use Livewire\Livewire;
-use MarcelWeidum\Passkeys\Livewire\Passkeys as LivewirePasskeys;
 
 final class PasskeysPlugin implements Plugin
 {
@@ -56,7 +54,5 @@ final class PasskeysPlugin implements Plugin
             fn (): View => view('filament-passkeys::profile'),
             scopes: $panel->getProfilePage() ?? EditProfile::class,
         );
-
-        Livewire::component('filament-passkeys', LivewirePasskeys::class);
     }
 }

--- a/src/PasskeysServiceProvider.php
+++ b/src/PasskeysServiceProvider.php
@@ -8,6 +8,8 @@ use Filament\Support\Assets\Asset;
 use Filament\Support\Assets\Css;
 use Filament\Support\Assets\Js;
 use Filament\Support\Facades\FilamentAsset;
+use Livewire\Livewire;
+use MarcelWeidum\Passkeys\Livewire\Passkeys as LivewirePasskey;
 use Spatie\LaravelPackageTools\Commands\InstallCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -58,6 +60,8 @@ final class PasskeysServiceProvider extends PackageServiceProvider
             $this->getAssets(),
             $this->getAssetPackageName()
         );
+
+        Livewire::component('filament-passkeys', LivewirePasskey::class);
     }
 
     protected function getAssetPackageName(): string


### PR DESCRIPTION
This does not work on filament version `4.x` so this should be in a new major version for filament version `5.x`.

---

* Removed the registration of the `filament-passkeys` Livewire component from the `PasskeysPlugin` class, including the related imports.
* Added the registration of the `filament-passkeys` Livewire component to the `PasskeysServiceProvider` class, including the necessary imports and the call to `Livewire::component` in the `packageBooted` method.