### PR TITLE
Fix: Move Livewire component registration to the register method for Laravel 12 support

### DIFF
--- a/src/PasskeysPlugin.php
+++ b/src/PasskeysPlugin.php
@@ -35,7 +35,7 @@ final class PasskeysPlugin implements Plugin
 
     public function register(Panel $panel): void
     {
-        //
+        Livewire::component('filament-passkeys', LivewirePasskeys::class);
     }
 
     public function boot(Panel $panel): void
@@ -56,7 +56,5 @@ final class PasskeysPlugin implements Plugin
             fn (): View => view('filament-passkeys::profile'),
             scopes: $panel->getProfilePage() ?? EditProfile::class,
         );
-
-        Livewire::component('filament-passkeys', LivewirePasskeys::class);
     }
 }


### PR DESCRIPTION
I've been using this great package in a new project running on Laravel 12 and Filament 5. While testing the profile page, I encountered a `Livewire\Exceptions\ComponentNotFoundException` stating that the `filament-passkeys` component could not be found.

The Issue: After some debugging, I realized that registering the Livewire component inside the `boot()` method of the `PasskeysPlugin` is causing a race condition in newer versions of Laravel/Livewire. The component needs to be registered earlier in the application lifecycle so that Livewire can find it during the initial request hydration.

The Fix: I moved the `Livewire::component()` registration from the `boot()` method to the `register()` method. This ensures that the component is registered as soon as the plugin is loaded by the Filament panel, resolving the "Component Not Found" error.