### PR TITLE
Drop filament 5 support for v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This package is using the [passkeys package from spatie](https://spatie.be/docs/
 
 &nbsp;
 
+The `2.x` version is for Filament v3 & v4. For Filament v5 support use the version [3.x](https://github.com/MarcelWeidum/filament-passkeys/tree/3.x).
+
 ## Installation
 
 1. Install the package via composer:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This package is using the [passkeys package from spatie](https://spatie.be/docs/
 
 &nbsp;
 
-The `2.x` version is for Filament v3 & v4. For Filament v5 support use the version [3.x](https://github.com/MarcelWeidum/filament-passkeys/tree/3.x).
+**Version compatibility:** `2.x` supports Filament v3 and v4. For Filament v5, use the [`3.x` branch](https://github.com/MarcelWeidum/filament-passkeys/tree/3.x).
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "filament/filament": "^4.0|^5.0",
+        "filament/filament": "^4.0",
         "spatie/laravel-package-tools": "^1.15.0",
         "spatie/laravel-passkeys": "^1.5.3",
         "web-auth/webauthn-lib": "5.2.3"


### PR DESCRIPTION
Drop filament v5 support for the `2.x` version of this package. For filament v3 and v4 use `2.x` and for filament v5 use `3.x`.