### PR TITLE
Fix: Allow string in deletePasskey method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": "^8.2",
         "filament/filament": "^5.0",
         "spatie/laravel-package-tools": "^1.15.0",
-        "spatie/laravel-passkeys": "^1.5.3",
+        "spatie/laravel-passkeys": "^1.7.1",
         "web-auth/webauthn-lib": "^5.2.4"
     },
     "require-dev": {

--- a/src/Livewire/Passkeys.php
+++ b/src/Livewire/Passkeys.php
@@ -27,7 +27,7 @@ final class Passkeys extends PasskeysComponent implements HasActions, HasSchemas
             ->action(fn (array $arguments) => $this->deletePasskey($arguments['passkey']));
     }
 
-    public function deletePasskey(int $passkeyId): void
+    public function deletePasskey(int|string $passkeyId): void
     {
         parent::deletePasskey($passkeyId);
 


### PR DESCRIPTION
Allow string in `deletePasskey()` method to support UUID identifiers.

`spatie/laravel-passkeys` already includes the proper fix: https://github.com/spatie/laravel-passkeys/pull/113, so the minimum required version has been bumped to 1.7.1.